### PR TITLE
Updated the rxdart version to 0.22.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  rxdart: ^0.20.0
+  rxdart: ^0.22.6
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
When I try to use AssetsAudioPlayer I get the error 'Because bloc >=0.13.0 depends on rxdart ^0.22.0 and every version of assets_audio_player depends on rxdart ^0.20.0, bloc >=0.13.0 is incompatible with assets_audio_player.
So, because meditation_alarm depends on both bloc ^2.0.0 and assets_audio_player ^1.0.0, version solving failed.'
Updating to the newest rxdart version should fix it.