### PR TITLE
Fix "resource not found" on iOS

### DIFF
--- a/ios/Classes/SwiftAssetsAudioPlayerPlugin.swift
+++ b/ios/Classes/SwiftAssetsAudioPlayerPlugin.swift
@@ -99,7 +99,7 @@ class Music : NSObject, AVAudioPlayerDelegate {
     }
     
     func open(asset: String, folder: String, result: FlutterResult){
-        guard let url = Bundle.main.url(forResource: asset, withExtension: "", subdirectory: "flutter_assets/"+folder) else {
+        guard let url = Bundle.main.url(forResource: asset, withExtension: "", subdirectory: "Frameworks/App.framework/flutter_assets/"+folder) else {
             log("resource not found "+asset)
             result("");
             return


### PR DESCRIPTION
Just copying the fix from [here](https://github.com/florent37/Flutter-AssetsAudioPlayer/issues/1#issuecomment-507635139) because I was trying to use this library on iOS.