### PR TITLE
fixes showing of subtext separator in notification

### DIFF
--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/NotificationService.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/NotificationService.kt
@@ -185,7 +185,11 @@ class NotificationService : Service() {
                 .setPriority(NotificationCompat.PRIORITY_MAX)
                 .setContentTitle(action.audioMetas.title)
                 .setContentText(action.audioMetas.artist)
-                .setSubText(action.audioMetas.album)
+                .also {
+                    if(!action.audioMetas.album.isNullOrEmpty()) {
+                        it.setSubText(action.audioMetas.album)
+                    }
+                }
                 .setContentIntent(PendingIntent.getBroadcast(this, 0,
                         createReturnIntent(forAction = NotificationAction.ACTION_SELECT, forPlayer = action.playerId), PendingIntent.FLAG_CANCEL_CURRENT))
                 .also {


### PR DESCRIPTION
This PR fixes issue with an extra separator in the notification, when the `album` name is null or empty. 

![Screenshot_1591132030 (1)](https://user-images.githubusercontent.com/7822179/83571800-16fa0800-a546-11ea-9b82-b7cd8dfa0266.jpg)
