### PR TITLE
update: hide published time in notification

### DIFF
--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/NotificationService.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/NotificationService.kt
@@ -197,6 +197,7 @@ class NotificationService : Service() {
                         it.setLargeIcon(bitmap)
                     }
                 }
+                .setShowWhen(false)
                 .build()
         startForeground(NOTIFICATION_ID, notification)
 


### PR DESCRIPTION
This PR fixes showing of notification published time, technically `setWhen` method. 
The "now" in notification doesn't make sense for an audio playing notification. Usually `when` is used to show elapsed time of notification was displayed. 

![Screenshot_1591132030 (1)](https://user-images.githubusercontent.com/7822179/83675927-81b74c00-a5f7-11ea-8702-200ee517cf0d.jpg)
