### PR TITLE
Fix seek on web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1+10
+
+* Fixed `seek` and `seekBy` not working on the web
+
 ## 2.0.1+9
 
 * Added `.showNotification = true/false` to hide dynamically displayed notification

--- a/assets_audio_player_web/lib/web/web_player_html.dart
+++ b/assets_audio_player_web/lib/web/web_player_html.dart
@@ -168,10 +168,14 @@ class WebPlayerHtml extends WebPlayer {
 
   @override
   void seek({double to}) {
-    if (_audioElement != null) {
-      if (to != null) {
-        _audioElement?.currentTime = to;
-      }
+    print("Final Seeking To $to from ${_audioElement.currentTime}");
+    if (_audioElement != null && to != null) {
+      /// Explainer on the `/1000`
+      /// The value being sent down from the plugin
+      /// is in `milliseconds` and `AudioElement` uses seconds.
+      /// This is to convert it.
+      double toInSeconds = to / 1000;
+      _audioElement?.currentTime = toInSeconds;
     }
   }
 

--- a/assets_audio_player_web/pubspec.yaml
+++ b/assets_audio_player_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: assets_audio_player_web
 description: Web plugin for assets_audio_player, play music/audio stored in assets files directly from Flutter.
-version: 2.0.1+9
+version: 2.0.1+10
 #author: Florent Champigny <champigny.florent@gmail.com>
 homepage: https://github.com/florent37/Flutter-AssetsAudioPlayer
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: assets_audio_player
 description: Play music/audio stored in assets files directly from Flutter & Network, Radio, LiveStream, Local files. Compatible with Android, iOS, web and MacOs
-version: 2.0.1+9
+version: 2.0.1+10
 #author: Florent Champigny <champigny.florent@gmail.com>
 homepage: https://github.com/florent37/Flutter-AssetsAudioPlayer
 


### PR DESCRIPTION
Fixes https://github.com/florent37/Flutter-AssetsAudioPlayer/issues/194

@florent37 I have bumped the version and added the changelog.
You can tweak it if required.

Also are you sure this seconds/milliseconds conversion problem is not happening elsewhere?