### PR TITLE
Fix Parralel Audio Playing on spamming notifications next,previous & play buttons or calling play multiple times.

### DIFF
--- a/lib/src/assets_audio_player.dart
+++ b/lib/src/assets_audio_player.dart
@@ -759,7 +759,7 @@ class AssetsAudioPlayer {
 
   Future<void> _openPlaylistCurrent(
       {bool autoStart = true, Duration seek}) async {
-    if (_playlist != null) {
+    if (_playlist != null && _isBuffering.value == false) {
       return _open(
         _playlist.currentAudio(),
         forcedVolume: _playlist.volume,


### PR DESCRIPTION
@florent37 

I tried to fix this one i found that the player should be created only when the isBuffering is false or the player is stop state.
Please look into the PR and see if this make sense.
I have tested livestream and @johnny-stevie  has tested other playing features network assets and local. 
 mentioning issue #290 