### PR TITLE
CustomPrevIcon fixed

### DIFF
--- a/lib/src/notification.dart
+++ b/lib/src/notification.dart
@@ -51,6 +51,7 @@ class NotificationSettings {
   final AndroidResDrawable customPlayIcon;
   final AndroidResDrawable customPauseIcon;
   final AndroidResDrawable customStopIcon;
+  final AndroidResDrawable customPrevIcon;
 
   //endregion
 
@@ -69,6 +70,7 @@ class NotificationSettings {
     this.customPlayIcon,
     this.customPreviousIcon,
     this.customStopIcon,
+    this.customPrevIcon,
   });
 }
 


### PR DESCRIPTION
CustomPrevIcon was not working due to missing lines in notification.dart. It is solved by adding this two lines. When we unable all the notification bar setting in our flutter project it shows a constant error CustomPrevIcon not found. When checking the Notification.dart file I found this two lines missing.
![2020-08-07 (2)](https://user-images.githubusercontent.com/55309783/89605566-7993bb00-d88b-11ea-9eb8-134a90510fc6.png)
