### PR TITLE
Included AudioType.network networkHeaders

### DIFF
--- a/lib/src/assets_audio_player.dart
+++ b/lib/src/assets_audio_player.dart
@@ -998,7 +998,8 @@ class AssetsAudioPlayer {
         if (audio.package != null) {
           params["package"] = audio.package;
         }
-        if (audio.audioType == AudioType.file ||
+        if (audio.audioType == AudioType.file || 
+            audio.audioType == AudioType.network || 
             audio.audioType == AudioType.liveStream) {
           params["networkHeaders"] =
               audio.networkHeaders ?? networkSettings.defaultHeaders;


### PR DESCRIPTION
I has a requirement to send headers to the server during audio fetching via AudioType.network. While cross-checking the code, I found AudioType.network was missing while centralizing the headers. Hence, I added the same to the existing condition. Now the headers are working fine for me.
The reason for omitting AudioType.network in while centralizing headers is unknown. 