### PR TITLE
A missing class name was added to README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ bool _play = false;
 
 @override
 Widget build(BuildContext context) {
-  return Audio.assets(
+  return AudioWidget.assets(
      path: "assets/audios/country.mp3",
      play: _play,
      child: RaisedButton(


### PR DESCRIPTION
There was a missing class name in the example which is in AudioWidget section.