### PR TITLE
Add conditional check for timeControl (macOS)

### DIFF
--- a/darwin/Classes/Music.swift
+++ b/darwin/Classes/Music.swift
@@ -679,7 +679,7 @@ public class Player : NSObject, AVAudioPlayerDelegate {
     
     
     private func addPlayerStatusListeners(item : AVQueuePlayer){
-        if #available(iOS 10.0, *){
+        if #available(iOS 10.0, OSX 10.12, *){
             observerStatus.append( item.observe(\.timeControlStatus, options: [.new]) { [weak self] (value, _) in
                 // show buffering
                 if(value.timeControlStatus == AVPlayer.TimeControlStatus.playing){


### PR DESCRIPTION
```
error: 'TimeControlStatus' is only available in macOS 10.12 or newer
```

fixes https://github.com/florent37/Flutter-AssetsAudioPlayer/issues/391