### PR TITLE
Set correct property elapsed playback time

### DIFF
--- a/darwin/Classes/Music.swift
+++ b/darwin/Classes/Music.swift
@@ -362,7 +362,7 @@ public class Player : NSObject, AVAudioPlayerDelegate {
         
         if ((self.notificationSettings ?? NotificationSettings()).seekBarEnabled) {
             self.nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = self.currentSongDurationMs / 1000
-            self.nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = _currentTime
+            self.nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = _currentTime / 1000
         } else {
             self.nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = 0
             self.nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = 0
@@ -892,7 +892,7 @@ public class Player : NSObject, AVAudioPlayerDelegate {
                 
                 if(self.displayMediaPlayerNotification){
                     #if os(iOS)
-                    self.nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = _currentTime
+                    self.nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = _currentTime / 1000
                     self.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = self.player!.rate
                     MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
                     #endif


### PR DESCRIPTION
After testing the latest 2.0.13 release which included a fix that enables the seekbar to ios users I encountered a bug.
The Elapsed Playback Time in the notification seekbar was incorrect (it was jumping every 10 minutes rather than every second)

This PR should fix this issue and show correctly the current playback position.