### PR TITLE
Remove delay when playing on iOS 10+

### DIFF
--- a/darwin/Classes/Music.swift
+++ b/darwin/Classes/Music.swift
@@ -830,7 +830,7 @@ public class Player : NSObject, AVAudioPlayerDelegate {
     
     func play(){
         if #available(iOS 10.0, *) {
-            self.player?.playImmediately(atRate: 1.0)
+            self.player?.playImmediately(atRate: self.rate)
         } else {
             self.player?.play()
             self.player?.rate = self.rate

--- a/darwin/Classes/Music.swift
+++ b/darwin/Classes/Music.swift
@@ -829,8 +829,12 @@ public class Player : NSObject, AVAudioPlayerDelegate {
     }
     
     func play(){
-        self.player?.play()
-        self.player?.rate = self.rate
+        if #available(iOS 10.0, *) {
+            self.player?.playImmediately(atRate: 1.0)
+        } else {
+            self.player?.play()
+            self.player?.rate = self.rate
+        }
         self.currentTimeTimer = Timer.scheduledTimer(timeInterval: 0.3, target: self, selector: #selector(updateTimer), userInfo: nil, repeats: true)
         self.currentTimeTimer?.fire()
 //        self.playing = true


### PR DESCRIPTION
On iOS 10+ add playImmediately to avoid unnecessary delay when playing