### PR TITLE
Fix Swift Compiler Warning - unused Music.swift variable

### DIFF
--- a/darwin/Classes/Music.swift
+++ b/darwin/Classes/Music.swift
@@ -609,7 +609,6 @@ public class Player : NSObject, AVAudioPlayerDelegate {
                     
                     result(nil)
                 case .failed:
-                    var error = item.error
                     debugPrint("playback failed")
                     
                     self?.stop()


### PR DESCRIPTION
```
.pub-cache/hosted/pub.dartlang.org/assets_audio_player-3.0.3+2/darwin/Classes/Music.swift:612:25: 
  Initialization of variable 'error' was never used; 
  consider replacing with assignment to '_' or removing it
```

Solution was to remove it.