### PR TITLE
fix: assetsAudioPlayer.open  playSpeed is not work

### DIFF
--- a/darwin/Classes/Music.swift
+++ b/darwin/Classes/Music.swift
@@ -537,6 +537,7 @@ public class Player : NSObject, AVAudioPlayerDelegate {
             } else {
                 item = SlowMoPlayerItem(url: url)
             }
+            item.audioTimePitchAlgorithm = .timeDomain
             self.player = AVQueuePlayer(playerItem: item)
             
             
@@ -590,12 +591,14 @@ public class Player : NSObject, AVAudioPlayerDelegate {
                         #endif
                     }
                     
+                    self?.setPlaySpeed(playSpeed: playSpeed)
+                    
                     if(autoStart == true){
                         self?.play()
                     }
                     
                     self?.setVolume(volume: volume)
-                    self?.setPlaySpeed(playSpeed: playSpeed)
+                  
                     
                     if(seek != nil){
                         self?.seek(to: seek!)


### PR DESCRIPTION
  1、assetsAudioPlayer.open api set autoStart and playSpeed is not work
2、playSpeed = 0.5 distortion of sound