### PR TITLE
[android] Added setPitch method

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,13 @@ You like the package ? buy me a kofi :)
           <td>✅</td>
           <td>✅</td>
         </tr>
+	<tr>
+          <td>⏩ get/set Pitch</td>
+          <td>✅</td>
+          <td>🚫</td>
+          <td>🚫</td>
+          <td>🚫</td>
+        </tr>
     </tbody>
 </table>
 
@@ -360,6 +367,13 @@ You like the package ? buy me a kofi :)
           <td>✅</td>
           <td>✅</td>
           <td>✅</td>
+        </tr>
+	<tr>
+          <td>🦻Listener Pitch</td>
+          <td>✅</td>
+          <td>🚫</td>
+          <td>🚫</td>
+          <td>🚫</td>
         </tr>
     </tbody>
 </table>
@@ -905,6 +919,42 @@ assetsAudioPlayer.loopMode.listen((loopMode){
 })
 
 assetsAudioPlayer.toggleLoop(); //toggle the value of looping
+```
+
+### 🏃 Play Speed
+
+```Dart
+assetsAudioPlayer.setPlaySpeed(1.5);
+
+assetsAudioPlayer.playSpeed.listen((playSpeed){
+    //listen to playSpeed
+})
+
+//change play speed for a particular Audio
+
+Audio audio = Audio.network(
+    url,
+    playSpeed: 1.5
+);
+assetsAudioPlayer.open(audio);
+```
+
+### 🎙️ Pitch
+
+```Dart
+assetsAudioPlayer.setPitch(1.2);
+
+assetsAudioPlayer.pitch.listen((pitch){
+    //listen to pitch
+})
+
+//change pitch for a particular Audio
+
+Audio audio = Audio.network(
+    url,
+    pitch: 1.2
+);
+assetsAudioPlayer.open(audio);
 ```
 
 

--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/AssetsAudioPlayerPlugin.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/AssetsAudioPlayerPlugin.kt
@@ -331,6 +331,23 @@ class AssetsAudioPlayer(
                     return
                 }
             }
+            "pitch" -> {
+                (call.arguments as? Map<*, *>)?.let { args ->
+                    val id = args["id"] as? String ?: run {
+                        result.error("WRONG_FORMAT", "The specified argument (id) must be an String.", null)
+                        return
+                    }
+                    val pitch = args["pitch"] as? Double ?: run {
+                        result.error("WRONG_FORMAT", "The specified argument must be an Double.", null)
+                        return
+                    }
+                    getOrCreatePlayer(id).setPitch(pitch)
+                    result.success(null)
+                } ?: run {
+                    result.error("WRONG_FORMAT", "The specified argument must be an Map<*, Any>.", null)
+                    return
+                }
+            }
             "showNotification" -> {
                 (call.arguments as? Map<*, *>)?.let { args ->
                     val id = args["id"] as? String ?: run {

--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/AssetsAudioPlayerPlugin.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/AssetsAudioPlayerPlugin.kt
@@ -27,6 +27,7 @@ internal val METHOD_POSITION = "player.position"
 internal val METHOD_VOLUME = "player.volume"
 internal val METHOD_FORWARD_REWIND_SPEED = "player.forwardRewind"
 internal val METHOD_PLAY_SPEED = "player.playSpeed"
+internal val METHOD_PITCH = "player.pitch"
 internal val METHOD_FINISHED = "player.finished"
 internal val METHOD_IS_PLAYING = "player.isPlaying"
 internal val METHOD_IS_BUFFERING = "player.isBuffering"
@@ -193,6 +194,9 @@ class AssetsAudioPlayer(
                 }
                 onPlaySpeedChanged = { speed ->
                     channel.invokeMethod(METHOD_PLAY_SPEED, speed)
+                }
+                onPitchChanged = { pitch ->
+                    channel.invokeMethod(METHOD_PITCH, pitch)
                 }
                 onPositionMSChanged = { positionMS ->
                     channel.invokeMethod(METHOD_POSITION, positionMS)
@@ -496,6 +500,10 @@ class AssetsAudioPlayer(
                         result.error("WRONG_FORMAT", "The specified argument must be an Map<String, Any> containing a `playSpeed`", null)
                         return
                     }
+                    val pitch = args["pitch"] as? Double ?: run {
+                        result.error("WRONG_FORMAT", "The specified argument must be an Map<String, Any> containing a `pitch`", null)
+                        return
+                    }
                     val autoStart = args["autoStart"] as? Boolean ?: true
                     val displayNotification = args["displayNotification"] as? Boolean ?: false
                     val respectSilentMode = args["respectSilentMode"] as? Boolean ?: false
@@ -528,6 +536,7 @@ class AssetsAudioPlayer(
                             notificationSettings = notificationSettings,
                             result = result,
                             playSpeed = playSpeed,
+                            pitch = pitch,
                             audioMetas = audioMetas,
                             headsetStrategy = headsetStrategy,
                             audioFocusStrategy = audioFocusStrategy,

--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/Player.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/Player.kt
@@ -51,6 +51,7 @@ class Player(
     //region outputs
     var onVolumeChanged: ((Double) -> Unit)? = null
     var onPlaySpeedChanged: ((Double) -> Unit)? = null
+    var onPitchChanged: ((Double) -> Unit)? = null
     var onForwardRewind: ((Double) -> Unit)? = null
     var onReadyToPlay: ((DurationMS) -> Unit)? = null
     var onSessionIdFound: ((Int) -> Unit)? = null
@@ -71,6 +72,7 @@ class Player(
     private var audioFocusStrategy: AudioFocusStrategy = AudioFocusStrategy.None
     private var volume: Double = 1.0
     private var playSpeed: Double = 1.0
+    private var pitch: Double = 1.0
 
     private var isEnabledToPlayPause: Boolean = true
     private var isEnabledToChangeVolume: Boolean = true
@@ -427,6 +429,20 @@ class Player(
             mediaPlayer?.let {
                 it.setPlaySpeed(playSpeed.toFloat())
                 onPlaySpeedChanged?.invoke(this.playSpeed)
+            }
+        }
+    }
+
+    fun setPitch(pitch: Double) {
+        if (pitch >= 0) { //android only take positive pitch
+            if (forwardHandler != null) {
+                forwardHandler!!.stop()
+                forwardHandler = null
+            }
+            this.pitch = pitch
+            mediaPlayer?.let {
+                it.setPitch(pitch.toFloat())
+                // onPlaySpeedChanged?.invoke(this.playSpeed)
             }
         }
     }

--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/Player.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/Player.kt
@@ -158,6 +158,7 @@ class Player(
              notificationSettings: NotificationSettings,
              audioMetas: AudioMetas,
              playSpeed: Double,
+             pitch: Double,
              headsetStrategy: HeadsetStrategy,
              audioFocusStrategy: AudioFocusStrategy,
              networkHeaders: Map<*, *>?,
@@ -213,6 +214,7 @@ class Player(
 
                 setVolume(volume)
                 setPlaySpeed(playSpeed)
+                setPitch(pitch)
 
                 seek?.let {
                     this@Player.seek(milliseconds = seek * 1L)
@@ -442,7 +444,7 @@ class Player(
             this.pitch = pitch
             mediaPlayer?.let {
                 it.setPitch(pitch.toFloat())
-                // onPlaySpeedChanged?.invoke(this.playSpeed)
+                onPitchChanged?.invoke(this.pitch)
             }
         }
     }

--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/playerimplem/PlayerImplem.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/playerimplem/PlayerImplem.kt
@@ -29,4 +29,5 @@ abstract class PlayerImplem(
     abstract fun seekTo(to: Long)
     abstract fun setVolume(volume: Float)
     abstract fun setPlaySpeed(playSpeed: Float)
+    abstract fun setPitch(pitch: Float)
 }

--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/playerimplem/PlayerImplemExoPlayer.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/playerimplem/PlayerImplemExoPlayer.kt
@@ -314,9 +314,16 @@ class PlayerImplemExoPlayer(
         mediaPlayer?.setPlaybackParameters(PlaybackParameters(playSpeed))
     }
 
+    override fun setPitch(pitch: Float) {
+        val params: PlaybackParameters? = mediaPlayer?.getPlaybackParameters()
+        if (params != null) {
+            mediaPlayer?.setPlaybackParameters(PlaybackParameters(params.speed, pitch))
+        }
+    }
+
     override fun getSessionId(listener: (Int) -> Unit) {
         val id = mediaPlayer?.audioComponent?.audioSessionId?.takeIf { it != AUDIO_SESSION_ID_UNSET }
-        if(id != null){
+        if (id != null) {
             listener(id)
         } else {
             val listener = object : AudioListener {

--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/playerimplem/PlayerImplemExoPlayer.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/playerimplem/PlayerImplemExoPlayer.kt
@@ -311,7 +311,10 @@ class PlayerImplemExoPlayer(
     }
 
     override fun setPlaySpeed(playSpeed: Float) {
-        mediaPlayer?.setPlaybackParameters(PlaybackParameters(playSpeed))
+        val params: PlaybackParameters? = mediaPlayer?.getPlaybackParameters()
+        if (params != null) {
+            mediaPlayer?.setPlaybackParameters(PlaybackParameters(playSpeed, params.pitch))
+        }
     }
 
     override fun setPitch(pitch: Float) {

--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/playerimplem/PlayerImplemMediaPlayer.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/playerimplem/PlayerImplemMediaPlayer.kt
@@ -207,10 +207,13 @@ class PlayerImplemMediaPlayer(
         //not possible
     }
 
+    override fun setPitch(pitch: Float) {
+        //not possible
+    }
+
     override fun getSessionId(listener: (Int) -> Unit) {
         mediaPlayer?.audioSessionId?.takeIf { it != 0 }?.let(listener)
     }
-
 }
 
 fun Map<*, *>.toMapString(): Map<String, String> {

--- a/lib/src/assets_audio_player.dart
+++ b/lib/src/assets_audio_player.dart
@@ -131,6 +131,9 @@ class AssetsAudioPlayer {
   static final double maxPlaySpeed = 16.0;
   static final double defaultVolume = maxVolume;
   static final double defaultPlaySpeed = 1.0;
+  static final double minPitch = 0.0;
+  static final double maxPitch = 16.0;
+  static final double defaultPitch = 1.0;
   static final AudioFocusStrategy defaultFocusStrategy =
       AudioFocusStrategy.request(resumeAfterInterruption: true);
   static final NotificationSettings defaultNotificationSettings =
@@ -1393,6 +1396,22 @@ class AssetsAudioPlayer {
     await _sendChannel.invokeMethod('playSpeed', {
       'id': id,
       'playSpeed': playSpeed.clamp(minPlaySpeed, maxPlaySpeed),
+    });
+  }
+
+  /// Change the current pitch of the MediaPlayer
+  ///
+  ///     _assetsAudioPlayer.setPitch(0.4);
+  ///
+  /// MIN : 0.0
+  /// MAX : 16.0
+  ///
+  /// if null, set to defaultPitch (1.0)
+  ///
+  Future<void> setPitch(double pitch) async {
+    await _sendChannel.invokeMethod('pitch', {
+      'id': id,
+      'pitch': pitch.clamp(minPitch, maxPitch),
     });
   }
 

--- a/lib/src/assets_audio_player.dart
+++ b/lib/src/assets_audio_player.dart
@@ -51,6 +51,7 @@ const String METHOD_NOTIFICATION_PREV = 'player.prev';
 const String METHOD_NOTIFICATION_STOP = 'player.stop';
 const String METHOD_NOTIFICATION_PLAY_OR_PAUSE = 'player.playOrPause';
 const String METHOD_PLAY_SPEED = 'player.playSpeed';
+const String METHOD_PITCH = 'player.pitch';
 const String METHOD_ERROR = 'player.error';
 const String METHOD_AUDIO_SESSION_ID = 'player.audioSessionId';
 
@@ -412,6 +413,10 @@ class AssetsAudioPlayer {
 
   ValueStream<double> get playSpeed => _playSpeed.stream;
 
+  final BehaviorSubject<double> _pitch = BehaviorSubject.seeded(1.0);
+
+  ValueStream<double> get pitch => _pitch.stream;
+
   final BehaviorSubject<double> _forwardRewindSpeed = BehaviorSubject.seeded(0);
 
   ValueStream<double> get forwardRewindSpeed => _forwardRewindSpeed.stream;
@@ -619,6 +624,9 @@ class AssetsAudioPlayer {
         case METHOD_PLAY_SPEED:
           _playSpeed.add(call.arguments);
           break;
+        case METHOD_PITCH:
+          _pitch.add(call.arguments);
+          break;
         case METHOD_FORWARD_REWIND_SPEED:
           final double newValue = call.arguments;
           if (_forwardRewindSpeed.value != newValue) {
@@ -803,6 +811,7 @@ class AssetsAudioPlayer {
         respectSilentMode: _playlist!.respectSilentMode,
         showNotification: _playlist!.showNotification,
         playSpeed: _playlist!.playSpeed,
+        pitch: _playlist!.pitch,
         notificationSettings: _playlist!.notificationSettings,
         autoStart: autoStart,
         loopMode: _playlist!.loopMode,
@@ -990,16 +999,17 @@ class AssetsAudioPlayer {
   // private method, used in open(playlist) and open(path)
   Future<void> _open(
     Audio? audioInput, {
-    bool? autoStart,
-    double? forcedVolume,
-    bool? respectSilentMode,
-    bool? showNotification,
-    Duration? seek,
-    double? playSpeed,
-    LoopMode? loopMode,
-    HeadPhoneStrategy? headPhoneStrategy,
-    AudioFocusStrategy? audioFocusStrategy,
-    NotificationSettings? notificationSettings,
+    required bool? autoStart,
+    required double? forcedVolume,
+    required bool? respectSilentMode,
+    required bool? showNotification,
+    required Duration? seek,
+    required double? playSpeed,
+    required double? pitch,
+    required LoopMode? loopMode,
+    required HeadPhoneStrategy? headPhoneStrategy,
+    required AudioFocusStrategy? audioFocusStrategy,
+    required NotificationSettings? notificationSettings,
   }) async {
     final _autoStart = autoStart ?? _DEFAULT_AUTO_START;
     final _loopMode = loopMode ?? _DEFAULT_LOOP_MODE;
@@ -1030,6 +1040,10 @@ class AssetsAudioPlayer {
               audio.playSpeed ??
               this.playSpeed.valueOrNull ??
               defaultPlaySpeed,
+          'pitch': pitch ??
+              audio.pitch ??
+              this.pitch.valueOrNull ??
+              defaultPitch,
         };
         if (seek != null) {
           params['seek'] = seek.inMilliseconds.round();
@@ -1111,6 +1125,7 @@ class AssetsAudioPlayer {
     bool showNotification = _DEFAULT_SHOW_NOTIFICATION,
     Duration? seek,
     double? playSpeed,
+    double? pitch,
     LoopMode? loopMode,
     NotificationSettings? notificationSettings,
     PlayInBackground? playInBackground,
@@ -1125,6 +1140,7 @@ class AssetsAudioPlayer {
       respectSilentMode: respectSilentMode,
       showNotification: showNotification,
       playSpeed: playSpeed,
+      pitch: pitch,
       loopMode: loopMode,
       audioFocusStrategy: audioFocusStrategy ?? defaultFocusStrategy,
       notificationSettings: notificationSettings,
@@ -1164,6 +1180,7 @@ class AssetsAudioPlayer {
     bool showNotification = _DEFAULT_SHOW_NOTIFICATION,
     Duration? seek,
     double? playSpeed,
+    double? pitch,
     NotificationSettings? notificationSettings,
     LoopMode loopMode = _DEFAULT_LOOP_MODE,
     PlayInBackground playInBackground = _DEFAULT_PLAY_IN_BACKGROUND,
@@ -1200,6 +1217,7 @@ class AssetsAudioPlayer {
           seek: seek,
           loopMode: loopMode,
           playSpeed: playSpeed,
+          pitch: pitch,
           headPhoneStrategy: headPhoneStrategy,
           audioFocusStrategy: focusStrategy,
           notificationSettings:
@@ -1467,6 +1485,7 @@ class _CurrentPlaylist {
   final bool? showNotification;
   LoopMode? loopMode;
   final double? playSpeed;
+  final double? pitch;
   final NotificationSettings? notificationSettings;
   final AudioFocusStrategy? audioFocusStrategy;
   final PlayInBackground? playInBackground;
@@ -1567,6 +1586,7 @@ class _CurrentPlaylist {
     this.respectSilentMode,
     this.showNotification,
     this.playSpeed,
+    this.pitch,
     this.notificationSettings,
     this.playInBackground,
     this.loopMode,

--- a/lib/src/playable.dart
+++ b/lib/src/playable.dart
@@ -162,6 +162,7 @@ class Audio extends Playable {
   final Map<String, String>? _networkHeaders;
   final bool? cached; // download audio then play it
   final double? playSpeed;
+  final double? pitch;
 
   Metas get metas => _metas;
 
@@ -173,6 +174,7 @@ class Audio extends Playable {
     this.package,
     this.cached,
     this.playSpeed,
+    this.pitch,
     Map<String, String>? headers,
     Metas? metas,
   })  : _metas = metas ?? Metas(),
@@ -183,6 +185,7 @@ class Audio extends Playable {
     Metas? metas,
     this.package,
     this.playSpeed,
+    this.pitch,
   })  : audioType = AudioType.asset,
         _networkHeaders = null,
         cached = false,
@@ -192,6 +195,7 @@ class Audio extends Playable {
     this.path, {
     Metas? metas,
     this.playSpeed,
+    this.pitch,
   })  : audioType = AudioType.file,
         package = null,
         _networkHeaders = null,
@@ -204,6 +208,7 @@ class Audio extends Playable {
     Map<String, String>? headers,
     this.cached = false,
     this.playSpeed,
+    this.pitch,
   })  : audioType = AudioType.network,
         package = null,
         _networkHeaders = headers,
@@ -213,6 +218,7 @@ class Audio extends Playable {
     this.path, {
     Metas? metas,
     this.playSpeed,
+    this.pitch,
     Map<String, String>? headers,
   })  : audioType = AudioType.liveStream,
         package = null,


### PR DESCRIPTION
**Additions**
- `setPitch` method to the `AssetsAudioPlayer` class, for changing pitch of the audio playback.
- `pitch` optional argument to `open` method of the `AssetsAudioPlayer` class.

**Notes** 
- A change has been made to `setPlaySpeed` (in `PlayerImplemExoPlayer`) method aswell, so as to ensure proper functioning. Alternative `PlaybackParameters` constructor is used now to enable pitch control aswell (More on that [here](https://exoplayer.dev/doc/reference/com/google/android/exoplayer2/PlaybackParameters.html#%3Cinit%3E(float,float))).
- This only works for Android, firstly because iOS does not have any equivalent, secondly I don't own a macOS running machine.

**Example**
Takes `pitch` as an argument, clamped between `0` & `16` just like `setPlaySpeed`.

```dart
_assetsAudioPlayer.setPitch(1.2);
```

I have confirmed the functionality & other things expected.
Code follows similar style as rest of the code.

Looking for review or requested changes to get this PR merged.
Thankyou.