### PR TITLE
#246: correct MIME-Type from "mp3" to "audio/mpeg""

### DIFF
--- a/darwin/Classes/Music.swift
+++ b/darwin/Classes/Music.swift
@@ -531,7 +531,7 @@ public class Player : NSObject, AVAudioPlayerDelegate {
             if networkHeaders != nil && networkHeaders!.count > 0 {
                 let asset = AVURLAsset(url: url, options: [
                     "AVURLAssetHTTPHeaderFieldsKey": networkHeaders!,
-                    "AVURLAssetOutOfBandMIMETypeKey": "mp3"
+                    "AVURLAssetOutOfBandMIMETypeKey": "audio/mpeg"
                 ])
                 item = SlowMoPlayerItem(asset: asset)
             } else {


### PR DESCRIPTION
The problem was that mp3 files from urls without extension were not played on iOS but on android they were. 

The following error message was thrown: `flutter: PlatformException(PLAY_ERROR, Cannot play https://{server-url}/files/8be4af2f-2c96-44ef-afcc-393267f2fc34, Cannot Open, null)`

With the change of the MIME type in the AVURLAsset from "mp3" to the correct MIME type "audio/mpeg" the files are now also played under iOS.