### PR TITLE
Prefer mavenCentral for Android builds.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     ext.kotlin_version = '1.4.31'
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -18,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
https://blog.gradle.org/jcenter-shutdown

jcenter is shutting down and this can cause Android build failures in some regions atm, and globally in the future.