### PR TITLE
Fix Typo in Readme.md Line number : 502

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ Custom icon (android only)
 
 ### By ResourceName
 
-Make sur you added those icons inside your `android/res/drawable` **!!! not on flutter assets !!!!**
+Make sure you added those icons inside your `android/res/drawable` **!!! not on flutter assets !!!!**
 
 ```dart
 await _assetsAudioPlayer.open(


### PR DESCRIPTION
Inside Readme.md in line 

> Make sur you added those icons inside your `android/res/drawable` **!!! not on flutter assets !!!!**

Replace **sur** with the word **sure**

> Make **sure** you added those icons inside your `android/res/drawable` **!!! not on flutter assets !!!!**
