### PR TITLE
add null check to widget bindings

### DIFF
--- a/lib/src/assets_audio_player.dart
+++ b/lib/src/assets_audio_player.dart
@@ -520,7 +520,7 @@ class AssetsAudioPlayer {
     _playerEditor = null;
 
     if (_lifecycleObserver != null) {
-      WidgetsBinding.instance.removeObserver(_lifecycleObserver!);
+      WidgetsBinding.instance?.removeObserver(_lifecycleObserver!);
       _lifecycleObserver = null;
     }
   }
@@ -690,7 +690,7 @@ class AssetsAudioPlayer {
       }
     });
     if (_lifecycleObserver != null) {
-      WidgetsBinding.instance.addObserver(_lifecycleObserver!);
+      WidgetsBinding.instance?.addObserver(_lifecycleObserver!);
     }
   }
 


### PR DESCRIPTION
There is an error on android & iOS which preventing build:
 - "Method 'removeObserver' cannot be called on 'WidgetsBinding?' because it is potentially null."
 - "Method 'addObserver' cannot be called on 'WidgetsBinding?' because it is potentially null."

Adding "?" to WidgetsBinding.instance fix that issue.