### PR TITLE
Bump kotlin version

### DIFF
--- a/assets_audio_player_web/android/build.gradle
+++ b/assets_audio_player_web/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.github.florent37.assets_audio_player_web'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
We were forced to raise the `gradle` version (as many probably did), but `assets_audio_player_web` contains an old version of `kotlin` - so this error occurs

```error
FAILURE: Build failed with an exception.

* What went wrong:
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.
The following dependencies do not satisfy the required version:
project ':assets_audio_player_web' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50
```

This little PR fixes that problem