### PR TITLE
Update gradle and gradle plugin, apply Android Studio suggestions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -48,22 +48,22 @@ android {
 
 dependencies {
 
-    def coroutinesVersion = "1.6.0"
+    def coroutinesVersion = '1.6.4'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:multidex:1.0.3'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
-    implementation "androidx.annotation:annotation:1.1.0"
+    implementation 'androidx.annotation:annotation:1.5.0'
 
 
-    def exoPlayerVersion = "2.17.1"
+    def exoPlayerVersion = '2.18.1'
 
     implementation "com.google.android.exoplayer:exoplayer:$exoPlayerVersion"
     implementation "com.google.android.exoplayer:exoplayer-hls:$exoPlayerVersion"
     implementation "com.google.android.exoplayer:exoplayer-dash:$exoPlayerVersion"
     implementation "com.google.android.exoplayer:exoplayer-smoothstreaming:$exoPlayerVersion"
-    implementation 'com.github.bumptech.glide:glide:4.13.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.13.0'
-    implementation "androidx.media:media:1.4.3"
+    implementation 'com.github.bumptech.glide:glide:4.14.2'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.14.2'
+    implementation 'androidx.media:media:1.6.0'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Nov 04 15:39:06 CET 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/assets_audio_player_web/android/build.gradle
+++ b/assets_audio_player_web/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -40,5 +40,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "androidx.annotation:annotation:1.1.0"
+    implementation 'androidx.annotation:annotation:1.5.0'
 }

--- a/assets_audio_player_web/android/gradle.properties
+++ b/assets_audio_player_web/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/assets_audio_player_web/android/gradle/wrapper/gradle-wrapper.properties
+++ b/assets_audio_player_web/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Fri Nov 04 15:36:21 CET 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
In a project I can't update from gradle `7.2.2` to `7.3.1` because of the old kotlin version of `assets_audio_player_web`.
This PR updates all dependencies that Android Studio showed and removes one deprecated line.

@kalismeras61 just saw that there already was a [merged PR](https://github.com/florent37/Flutter-AssetsAudioPlayer/pull/730). Could you please publish new versions?
And I think it can't hurt to bump the dependencies to the latest stable versions, as in this PR - if they're working correctly 😊

<img width="673" alt="Screenshot 2022-11-04 at 15 42 38" src="https://user-images.githubusercontent.com/43643339/200003207-b70152da-3316-444b-809c-615f750309f6.png">

