### PR TITLE
[Android] Remove deprecated splash screen meta-data element

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -30,15 +30,6 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
-            <!-- Displays an Android View that continues showing the launch screen
-                 Drawable until Flutter paints its first frame, then this splash
-                 screen fades out. A splash screen is useful to avoid any visual
-                 gap between the end of Android's launch screen and the painting of
-                 Flutter's first frame. -->
-            <meta-data
-              android:name="io.flutter.embedding.android.SplashScreenDrawable"
-              android:resource="@drawable/launch_background"
-              />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>


### PR DESCRIPTION
Deletes deprecated splash screen meta-data element in example app.

This is no longer needed to present a splash screen in a Flutter application, but may cause a crash. Please see [Deprecated Splash Screen API Migration Guide](https://docs.flutter.dev/development/platform-integration/android/splash-screen-migration) for more information.