### PR TITLE
Switch to AndroidX, drop Jetifier, update Kotlin dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.20'
+    ext.kotlin_version = '1.7.21'
     repositories {
         google()
         mavenCentral()
@@ -50,12 +50,10 @@ dependencies {
 
     def coroutinesVersion = '1.6.4'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:multidex:1.0.3'
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "androidx.multidex:multidex:2.0.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
     implementation 'androidx.annotation:annotation:1.5.0'
-
 
     def exoPlayerVersion = '2.18.1'
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Nov 04 15:39:06 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Thanks for this project. 
I use this package in one of work projects and recently bumped into an issue that Android builds started to fail after I tried to remove [Jetifier](https://developer.android.com/studio/command-line/jetifier) from the project as thought that all dependencies already switched to AndroidX. 

As it turned out `asset_audio_player` had old `support` multidex dependency. In this PR I switched to newer version, which is already an AndroidX dependency, thus, would allow to also drop `android.enableJetifier=true` as Jetifier has effect on incremental build speed: https://adambennett.dev/2020/08/disabling-jetifier/

Finally, did some minor version updates and dropped redundant `kotlinx-coroutines-core` dependency as `kotlinx:kotlinx-coroutines-android` is enough for Android projects.