### PR TITLE
Glide exception already resumed crash

### DIFF
--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/ImageDownloader.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/ImageDownloader.kt
@@ -142,9 +142,7 @@ object ImageDownloader {
                                                 continuation.resume(placeHolder)
                                             }
                                         } catch (t : Throwable) {
-                                            if(t.message != "Already resumed"){
-                                                continuation.resumeWithException(Exception("failed to download $filePath"))
-                                            }
+
                                         }
                                     }
 

--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/ImageDownloader.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/ImageDownloader.kt
@@ -142,7 +142,9 @@ object ImageDownloader {
                                                 continuation.resume(placeHolder)
                                             }
                                         } catch (t : Throwable) {
-                                            continuation.resumeWithException(Exception("failed to download $filePath"))
+                                            if (t.message != "Already resumed") {
+                                                continuation.resumeWithException(Exception("failed to download $filePath"))
+                                            }
                                         }
                                     }
 

--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/ImageDownloader.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/ImageDownloader.kt
@@ -142,7 +142,7 @@ object ImageDownloader {
                                                 continuation.resume(placeHolder)
                                             }
                                         } catch (t : Throwable) {
-                                            if(t.message != 'Already resumed'){
+                                            if(t.message != "Already resumed"){
                                                 continuation.resumeWithException(Exception("failed to download $filePath"))
                                             }
                                         }

--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/ImageDownloader.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/ImageDownloader.kt
@@ -142,7 +142,9 @@ object ImageDownloader {
                                                 continuation.resume(placeHolder)
                                             }
                                         } catch (t : Throwable) {
-                                            continuation.resumeWithException(Exception("failed to download $filePath"))
+                                            if(t.message != 'Already resumed'){
+                                                continuation.resumeWithException(Exception("failed to download $filePath"))
+                                            }
                                         }
                                     }
 

--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/ImageDownloader.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/ImageDownloader.kt
@@ -142,7 +142,7 @@ object ImageDownloader {
                                                 continuation.resume(placeHolder)
                                             }
                                         } catch (t : Throwable) {
-
+                                            continuation.resumeWithException(Exception("failed to download $filePath"))
                                         }
                                     }
 

--- a/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/ImageDownloader.kt
+++ b/android/src/main/kotlin/com/github/florent37/assets_audio_player/notification/ImageDownloader.kt
@@ -142,7 +142,7 @@ object ImageDownloader {
                                                 continuation.resume(placeHolder)
                                             }
                                         } catch (t : Throwable) {
-                                            if (t.message != "Already resumed") {
+                                            if(t.message != "Already resumed"){
                                                 continuation.resumeWithException(Exception("failed to download $filePath"))
                                             }
                                         }


### PR DESCRIPTION
i faced a crash when i start an audio using file constructor 
and i am with no internet 
when i pause the audio then connect device to internet the app crashes 
when i logged the error i faced Already resumed in glide so i tried to handle this to not throwing an unhandled exception
by wrapping with if condition