### PR TITLE
Update dependencies and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,20 +37,9 @@ AssetsAudioPlayer.newPlayer().open(
 ```yaml
 dependencies:
   assets_audio_player: ^3.0.8
-
-or
-
-recommend to use below. While we don't have access pub... 
-
-assets_audio_player:
-git:
-url: https://github.com/florent37/Flutter-AssetsAudioPlayer.git
-ref: master
-
-ref can be latest commit id.
 ```
 
-**Works with `flutter: ">=1.12.13+hotfix.6 <2.0.0"`, be sure to upgrade your sdk**
+**Works with `flutter: ">=3.3.0"`, be sure to upgrade your sdk**
 
 You like the package ? buy me a kofi :)
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml

--- a/assets_audio_player_web/analysis_options.yaml
+++ b/assets_audio_player_web/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml

--- a/assets_audio_player_web/pubspec.yaml
+++ b/assets_audio_player_web/pubspec.yaml
@@ -5,20 +5,19 @@ version: 3.1.1
 homepage: https://github.com/florent37/Flutter-AssetsAudioPlayer
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  #flutter_web_howl: ^1.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.11.1
+  flutter_lints: ^2.0.2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
@@ -41,34 +40,3 @@ flutter:
       web:
         pluginClass: AssetsAudioPlayerWebPlugin
         fileName: web/assets_audio_player_web.dart
-
-  # To add assets to your plugin package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific 'variants', see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your plugin package, add a fonts section here,
-  # in this 'flutter' section. Each entry in this list should have a
-  # 'family' key with the font family name, and a 'fonts' key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,14 +6,14 @@ version: 3.1.1
 homepage: https://github.com/florent37/Flutter-AssetsAudioPlayer
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.19.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  rxdart: ^0.27.3
-  uuid: ^3.0.5
+  rxdart: ^0.27.7
+  uuid: ">=3.0.7 <5.0.0"
   http: ">=0.13.0 <2.0.0" # to download / cache network files
   path_provider: ^2.0.8 # removed this because it cancel flutter/android/ios on pub.dev path_provider: ^1.6.10
 
@@ -28,7 +28,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.11.1
+  flutter_lints: ^2.0.2
 
 flutter:
   plugin:


### PR DESCRIPTION
Updated Flutter/Dart dependencies for better compatibility with current state of Flutter ecosystem.

- Replaced `pedantic` with `flutter_lints` as it is deprecated for quite some time already: https://pub.dev/packages/pedantic
Note, I used not `2.0.3` version as it bumps min Flutter to 3.7.0, so stayed with `2.0.2` to have better compatibility with projects with Flutter >3.3.0
- Updated `uuid` to a range of versions for broader compatibility and because 3.x versions are compatible with 4.x versions according to README: https://pub.dev/packages/uuid#uuid
- Updated Flutter and Dart constraints to correspond to dependencies and not confuse users about package compatibility.
- Updated README to remove some outdated information